### PR TITLE
Branding for landing page and webapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,12 @@ The default layouts can also be overridden in a similar manner.
 
 Files worth mentioning are:
 
+ - `landing-page/default/content/branding.yaml`: optional branding details.
  - `landing-page/default/content/contacts.yaml`: the list of contacts to show
    in the sidebar.
  - `landing-page/default/content/links.yaml`: the list of links to show in the
    sidebar.
- - `landing-page/default/content/environment.md`: the environment details
-   including
-   some metadata.
+ - `landing-page/default/content/environment.md`: the environment details.
 
 Once any changes have been made, make sure to compile the site.  The command
 to do that depends on the installation method.

--- a/landing-page/Rules
+++ b/landing-page/Rules
@@ -24,6 +24,11 @@ preprocess do
   # end
 end
 
+compile '/branding.*' do
+  filter :metadata_to_json, item: item
+  write ext: 'json'
+end
+
 compile '/contacts/*' do
   filters_from_extensions(item).each do |f|
     filter f

--- a/landing-page/lib/helpers.rb
+++ b/landing-page/lib/helpers.rb
@@ -1,5 +1,19 @@
 use_helper Nanoc::Helpers::Rendering
 
+def branding(dotted_key="")
+  raw_branding = items['/branding.yaml']
+  return if raw_branding.nil?
+
+  keys = dotted_key.split('.')
+  keys.reduce(raw_branding) do |accum, key|
+    if accum.respond_to?(:[])
+      accum[key.to_sym]
+    else
+      nil
+    end
+  end
+end
+
 def raw_contacts
   c = items['/contacts.yaml']
   if !c.nil?
@@ -71,8 +85,8 @@ def filters_from_extensions(item)
 end
 
 def has_sidenav_content?
-  environment[:name] ||
-    environment[:organisation_name] ||
+  branding('environment.name') ||
+    branding('organisation.name') ||
     !contacts.empty? ||
     !links.empty?
 end

--- a/landing-page/lib/metadata_to_json.rb
+++ b/landing-page/lib/metadata_to_json.rb
@@ -1,0 +1,20 @@
+class MetadataToJson < Nanoc::Filter
+  identifier :metadata_to_json
+
+  NANOC_KEYS = [:filename, :content_filename, :meta_filename, :extension, :mtime].freeze
+
+  def run(content, params = {})
+    item = params[:item]
+    hash_except(NANOC_KEYS, item.attributes).to_json
+  end
+
+  private
+
+  def hash_except(keys, hash)
+    hash.dup.tap do |dup|
+      keys.each do |key|
+        dup.delete(key)
+      end
+    end
+  end
+end

--- a/landing-page/types/headnode/content/branding.yaml
+++ b/landing-page/types/headnode/content/branding.yaml
@@ -1,0 +1,46 @@
+# Optional branding for the landing page AND flight webapps.
+
+# environment:
+#   # Optional cluster (or environment) name.  Defaults to an empty string if
+#   # not provided.
+#   name: "BigV Cluster"
+
+# organisation:
+#   # Optional organisation name.  Defaults to an empty string if not provided.
+#   name: "The University of BigV"
+
+# brandbar:
+#   # Optional text for the brandbar, for both the landing page and the webapps.
+#   # Defaults to an empty string if not provided.
+#   text: "BigV Uni"
+
+#   # Optional logo for the brandbar, for both the landing page and the webapps.
+#   # Defaults to the OpenflightHPC logo if not provided.
+#   logo:
+#     url: "http://localhost:3001/bigv-uni.png"
+#     alt: "University of BigV logo"
+#     # Additional class names for the IMG tag.  Bootstrap classes can be used
+#     # here.
+#     classNames: ""
+
+# landingpage:
+#   dashboard:
+#     # Optional logo for the landing page environment page (aka dashboard).
+#     # Defaults to no logo if not provided.
+#     logo:
+#       url: "http://localhost:3001/bigv-uni.png"
+#       alt: "University of BigV logo"
+#       # Additional class names for the IMG tag.  Bootstrap classes can be used
+#       # here.
+#       classNames: "mb-4"
+
+# apps:
+#   dashboard:
+#     # Optional logo for the webapp dashboards.
+#     # Defaults to the OpenflightHPC logo if not provided.
+#     logo:
+#       url: "http://localhost:3001/bigv-uni.png"
+#       alt: "University of BigV logo"
+#       # Additional class names for the IMG tag.  Bootstrap classes can be used
+#       # here.
+#       classNames: "mb-4"

--- a/landing-page/types/headnode/content/environment.md
+++ b/landing-page/types/headnode/content/environment.md
@@ -1,21 +1,3 @@
----
-# This section is the front matter.  It is optional but if present must be a
-# YAML object.  The key/values defined here are used by the layouts when
-# rendering this content.
-
-# optional: The URL for the environment's or organisation's logo.
-logo_url: /images/png_trans_logo.png
-
-# optional: The name of the environment.
-#name: Demo Cluster
-
-# optional: The name of the organisation that the environment belongs to.
-#organisation_name: Demo organisation
----
-
-<!-- This is markdown.  The content is rendered and displayed prominently on
-the landing page.  -->
-
 This environment is powered by OpenflightHPC Compute and the Flight User
 Suite.
 

--- a/landing-page/types/headnode/content/styles/branding.css
+++ b/landing-page/types/headnode/content/styles/branding.css
@@ -1,0 +1,21 @@
+.BrandingTextWrapper {
+    padding-top: 1rem;
+}
+.BrandingText {
+    font-weight: bold;
+    font-size: larger;
+    color: rgba(0,0,0,.5);
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.BrandingBrandbarLogo {
+    height: 75px;
+}
+
+.BrandingDashboardLogo {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-height: 300px;
+}

--- a/landing-page/types/headnode/layouts/default.html.erb
+++ b/landing-page/types/headnode/layouts/default.html.erb
@@ -21,6 +21,7 @@
     <!-- Our party styles -->
     <link rel="stylesheet" href="/styles/openflight.css">
     <link rel="stylesheet" href="/styles/app.css">
+    <link rel="stylesheet" href="/styles/branding.css">
 
     <script
         src="https://code.jquery.com/jquery-3.3.1.slim.min.js"

--- a/landing-page/types/headnode/layouts/environment.html.erb
+++ b/landing-page/types/headnode/layouts/environment.html.erb
@@ -1,14 +1,14 @@
 <div class="environment">
-  <% if @item[:logo_url] %>
+  <% if branding('landingpage.dashboard.logo') %>
     <div class="mb-2">
       <img
-        src="<%= @item[:logo_url] %>"
-        alt="Environment Logo"
-        class="logo"
+        src="<%= branding('landingpage.dashboard.logo.url') %>"
+        alt="<%= branding('landingpage.dashboard.logo.alt') || 'Environment logo' %>"
+        class="logo <%= branding('landingpage.dashboard.logo.classNames') %>"
         >
       </img>
     </div>
   <% end %>
-  <h3 class="text-center"><%= @item[:name] %></h3>
+  <h3 class="text-center"><%= branding('environment.name') %></h3>
   <%= yield %>
 </div>

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -1,13 +1,32 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom">
-    <a
+    <% if branding('brandbar.logo') %>
+      <a
+        class="navbar-brand <%= branding('brandbar.logo.classNames') %>"
+        href="/">
+        <img
+          src="<%= branding('brandbar.logo.url') %>"
+          alt="<%= branding('brandbar.logo.alt') %>"
+          height="75">
+        </img>
+      </a>
+    <% else %>
+      <a
         class="navbar-brand"
         href="/">
         <img
-            src="/images/png_trans_logo-navbar.png"
-            alt="openflightHPC Logo"
-            height="75">
+          src="/images/png_trans_logo-navbar.png"
+          alt="openflightHPC Logo"
+          height="75">
         </img>
-    </a>
+      </a>
+    <% end %>
+    <% if text = branding('brandbar.text') %>
+      <div class="BrandingTextWrapper">
+        <span class="BrandingText">
+          <%= text %>
+        </span>
+      </div>
+    <% end %>
 
     <button
         class="navbar-toggler"

--- a/landing-page/types/headnode/layouts/sidebar.html.erb
+++ b/landing-page/types/headnode/layouts/sidebar.html.erb
@@ -1,16 +1,16 @@
 <aside class="sidenav col-12 col-md-3 col-lg-2">
   <div>
-    <% unless environment[:name].nil? %>
+    <% unless branding('environment.name').nil? %>
       <h2>Environment</h2>
       <ul class="w-100">
-        <li><%= environment[:name] %></li>
+        <li><%= branding('environment.name') %></li>
       </ul>
     <% end %>
 
-    <% unless environment[:organisation_name].nil? %>
+    <% unless branding('organisation.name').nil? %>
       <h2>Organisation</h2>
       <ul class="w-100">
-        <li><%= environment[:organisation_name] %></li>
+        <li><%= branding('organisation.name') %></li>
       </ul>
     <% end %>
 


### PR DESCRIPTION
Add support for branding the landing page and providing that branding information to the webapps.

The metadata that was previously specified in `default/content/environment.md` has been moved to `default/content/branding.yaml` and extended to support additional branding information.  That file is made available to the webapps at the URL `/branding.json`.

The branding currently possible for the landing page is:

1. Change the logo used in the brandbar.
2. Add additional text in the brandbar.
3. Change the logo used in the main content of the landing page.
4. Add the environment name and organisation name to the side bar.

There is a PR adding branding support to `flight-job-script-webapp` see (https://github.com/openflighthpc/flight-job-script-service/pull/5).  That PR adds support for branding to

1. Change the logo used in the brandbar.
2. Add additional text in the brandbar.
3. Change the logo used on the dashboards.

Adding additional branding opportunities should be relatively straightforward.
