### PR TITLE
Allow config packs to be display on the landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /landing-page/types/headnode/content/apps/*
 /landing-page/types/headnode/content/config-packs/*
+!/landing-page/types/headnode/content/config-packs/demo.md.disabled
 /landing-page/overridden/
 /landing-page/branding
 /landing-page/output

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/landing-page/default/content/apps
+/landing-page/types/headnode/content/apps/*
+/landing-page/types/headnode/content/config-packs/*
 /landing-page/overridden/
 /landing-page/branding
 /landing-page/output

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /landing-page/types/headnode/content/apps/*
 /landing-page/types/headnode/content/config-packs/*
-!/landing-page/types/headnode/content/config-packs/demo.md.disabled
+!/landing-page/types/headnode/content/config-packs/example.md.disabled
 /landing-page/overridden/
 /landing-page/branding
 /landing-page/output

--- a/landing-page/Rules
+++ b/landing-page/Rules
@@ -24,6 +24,8 @@ preprocess do
   # end
 end
 
+ignore '/**/*.disabled'
+
 compile '/data/*.yaml' do
   filter :metadata_to_json, item: item
   write ext: 'json'

--- a/landing-page/Rules
+++ b/landing-page/Rules
@@ -69,6 +69,16 @@ compile '/apps/*' do
   write nil
 end
 
+compile '/config-packs/*' do
+  filters_from_extensions(item).each do |f|
+    filter f
+  end
+  layout '/config-pack.*'
+  snapshot :pre_default
+
+  write nil
+end
+
 compile '/**/*.html' do
   snapshot :pre_default
   layout '/default.*'

--- a/landing-page/lib/helpers.rb
+++ b/landing-page/lib/helpers.rb
@@ -68,7 +68,7 @@ end
 def app_items
   @_apps ||= items
     .find_all('/apps/**/*')
-    .reject { |i| /\.disabled\Z/.match?(i.identifier) || i[:disabled] }
+    .reject { |i| /\.disabled\Z/.match?(i.identifier) }
     .sort { |a, b|
       if a[:order] && b[:order]
         [ a[:order], a.identifier ] <=> [ b[:order], b.identifier ]
@@ -86,7 +86,7 @@ end
 
 def config_pack_items
   @__config_packs ||= items.find_all('/config-packs/**/*')
-                           .reject { |i| /\.disabled\Z/.match?(i.identifier) || i[:disabled] }
+                           .reject { |i| /\.disabled\Z/.match?(i.identifier) }
                            .sort do |a, b|
     if a[:order] && b[:order]
       [ a[:order], a.identifier ] <=> [ b[:order], b.identifier ]

--- a/landing-page/lib/helpers.rb
+++ b/landing-page/lib/helpers.rb
@@ -68,6 +68,7 @@ end
 def app_items
   @_apps ||= items
     .find_all('/apps/**/*')
+    .reject { |i| /\.disabled\Z/.match?(i.identifier) || i[:disabled] }
     .sort { |a, b|
       if a[:order] && b[:order]
         [ a[:order], a.identifier ] <=> [ b[:order], b.identifier ]
@@ -85,6 +86,7 @@ end
 
 def config_pack_items
   @__config_packs ||= items.find_all('/config-packs/**/*')
+                           .reject { |i| /\.disabled\Z/.match?(i.identifier) || i[:disabled] }
                            .sort do |a, b|
     if a[:order] && b[:order]
       [ a[:order], a.identifier ] <=> [ b[:order], b.identifier ]

--- a/landing-page/lib/helpers.rb
+++ b/landing-page/lib/helpers.rb
@@ -79,6 +79,23 @@ def app_items
     }
 end
 
+def config_packs_item
+  items['/config-packs.*']
+end
+
+def config_pack_items
+  @__config_packs ||= items.find_all('/config-packs/**/*')
+                           .sort do |a, b|
+    if a[:order] && b[:order]
+      [ a[:order], a.identifier ] <=> [ b[:order], b.identifier ]
+    elsif a[:order].nil? && b[:order].nil?
+      a.identifier <=> b.identifier
+    else
+      a[:order] ? -1 : 1
+    end
+  end
+end
+
 def blurb
   items['/blurb.*']
 end

--- a/landing-page/types/headnode/content/apps.html.erb
+++ b/landing-page/types/headnode/content/apps.html.erb
@@ -2,10 +2,10 @@
   <div class="mb-4">
     <h2>Web Suite Tools</h2>
     <a id="apps"></a>
-    <p class="d-none https-d-block">
+    <p class="d-none" data-https-d-block>
     Your environment has the following web tools installed and ready for use.
     </p>
-    <div class="d-none http-d-block">
+    <div class="d-none" data-http-d-block>
       <p>
       The Flight Web Suite is not currently available as HTTPS has not been
       enabled for your environment.  To learn more about HTTPS and how to enable

--- a/landing-page/types/headnode/content/apps.html.erb
+++ b/landing-page/types/headnode/content/apps.html.erb
@@ -1,27 +1,29 @@
 <% unless app_items.empty? %>
-  <h2>Web Suite Tools</h2>
-  <a id="apps"></a>
-  <p class="d-none https-d-block">
-  Your environment has the following web tools installed and ready for use.
-  </p>
-  <div class="d-none http-d-block">
-    <p>
-    The Flight Web Suite is not currently available as HTTPS has not been
-    enabled for your environment.  To learn more about HTTPS and how to enable
-    it click the <em>Learn more</em> button below.
+  <div class="mb-4">
+    <h2>Web Suite Tools</h2>
+    <a id="apps"></a>
+    <p class="d-none https-d-block">
+    Your environment has the following web tools installed and ready for use.
     </p>
-    <div class="clearfix mb-4">
-      <a
-        class="btn btn-primary learn-more float-right"
-        href="/enable-https"
-      >
-        Learn more
-      </a>
+    <div class="d-none http-d-block">
+      <p>
+      The Flight Web Suite is not currently available as HTTPS has not been
+      enabled for your environment.  To learn more about HTTPS and how to enable
+      it click the <em>Learn more</em> button below.
+      </p>
+      <div class="clearfix mb-4">
+        <a
+          class="btn btn-primary learn-more float-right"
+          href="/enable-https"
+        >
+          Learn more
+        </a>
+      </div>
     </div>
-  </div>
-  <div class="card-deck app-card-deck">
-    <% app_items.each do |app| %>
-      <%= app.compiled_content(snapshot: :pre_default) %>
-    <% end %>
+    <div class="card-deck app-card-deck">
+      <% app_items.each do |app| %>
+        <%= app.compiled_content(snapshot: :pre_default) %>
+      <% end %>
+    </div>
   </div>
 <% end %>

--- a/landing-page/types/headnode/content/config-packs.html.erb
+++ b/landing-page/types/headnode/content/config-packs.html.erb
@@ -1,12 +1,14 @@
 <% unless config_pack_items.empty? %>
-  <h2>Config Packs</h2>
-  <a id="config-packs"></a>
-  <p>
-  Your environment has the following tool packs installed and ready for use.
-  </p>
-  <div class="card-deck config-pack-card-deck">
-    <% config_pack_items.each do |config| %>
-      <%= config.compiled_content(snapshot: :pre_default) %>
-    <% end %>
+  <div class="mb-4">
+    <h2>Config Packs</h2>
+    <a id="config-packs"></a>
+    <p>
+    Your environment has the following tool packs installed and ready for use.
+    </p>
+    <div class="card-deck config-pack-card-deck">
+      <% config_pack_items.each do |config| %>
+        <%= config.compiled_content(snapshot: :pre_default) %>
+      <% end %>
+    </div>
   </div>
 <% end %>

--- a/landing-page/types/headnode/content/config-packs.html.erb
+++ b/landing-page/types/headnode/content/config-packs.html.erb
@@ -3,7 +3,7 @@
     <h2>Config Packs</h2>
     <a id="config-packs"></a>
     <p>
-    Your environment has the following config packs installed and ready for use.
+    Your environment has the following config packs for you to download.
     </p>
     <div class="card-deck config-pack-card-deck">
       <% config_pack_items.each do |config| %>

--- a/landing-page/types/headnode/content/config-packs.html.erb
+++ b/landing-page/types/headnode/content/config-packs.html.erb
@@ -1,5 +1,5 @@
 <% unless config_pack_items.empty? %>
-  <h2>Tool Packs</h2>
+  <h2>Config Packs</h2>
   <a id="config-packs"></a>
   <p>
   Your environment has the following tool packs installed and ready for use.

--- a/landing-page/types/headnode/content/config-packs.html.erb
+++ b/landing-page/types/headnode/content/config-packs.html.erb
@@ -3,7 +3,7 @@
     <h2>Config Packs</h2>
     <a id="config-packs"></a>
     <p>
-    Your environment has the following tool packs installed and ready for use.
+    Your environment has the following config packs installed and ready for use.
     </p>
     <div class="card-deck config-pack-card-deck">
       <% config_pack_items.each do |config| %>

--- a/landing-page/types/headnode/content/config-packs.html.erb
+++ b/landing-page/types/headnode/content/config-packs.html.erb
@@ -1,0 +1,12 @@
+<% unless config_pack_items.empty? %>
+  <h2>Tool Packs</h2>
+  <a id="config-packs"></a>
+  <p>
+  Your environment has the following tool packs installed and ready for use.
+  </p>
+  <div class="card-deck config-pack-card-deck">
+    <% config_pack_items.each do |config| %>
+      <%= config.compiled_content(snapshot: :pre_default) %>
+    <% end %>
+  </div>
+<% end %>

--- a/landing-page/types/headnode/content/config-packs/demo.md.disabled
+++ b/landing-page/types/headnode/content/config-packs/demo.md.disabled
@@ -1,0 +1,22 @@
+---
+disabled: false # The .disabled file extension takes precedence
+title: Example Config
+short_title: Example
+subtitle: An example config pack
+downloads:
+  - README.md
+  - [Tarball, example.tar.gz]
+---
+This is an example config pack that you can copy to create your own.
+Please refer to the following for the metadata specification:<br>
+`/opt/flight/opt/www/landing-page/default/content/config-packs/demo.md.disabled`
+
+The listed `downloads` need to be stored in:<br>
+`/opt/flight/usr/share/www/downloads/config-packs/<PACK NAME>/`
+
+In this case, the paths will be:<br>
+`/opt/flight/usr/share/www/downloads/config-packs/example/README.md`
+`/opt/flight/usr/share/www/downloads/config-packs/example/example.tar.gz`
+
+You may hide this config pack by removing the symlink:<br>
+`rm /opt/flight/opt/www/landing-page/default/content/config-packs/demo.md`

--- a/landing-page/types/headnode/content/config-packs/demo.md.disabled
+++ b/landing-page/types/headnode/content/config-packs/demo.md.disabled
@@ -7,6 +7,7 @@ downloads:
   - file_name: README.md
   - file_name: example.tar.gz
     display_name: Tarball
+    fa_icon: file-archive-o
 ---
 This is an example config pack that you can copy to create your own.
 Please refer to the following for the metadata specification:<br>

--- a/landing-page/types/headnode/content/config-packs/demo.md.disabled
+++ b/landing-page/types/headnode/content/config-packs/demo.md.disabled
@@ -4,8 +4,9 @@ title: Example Config
 short_title: Example
 subtitle: An example config pack
 downloads:
-  - README.md
-  - [Tarball, example.tar.gz]
+  - file_name: README.md
+  - file_name: example.tar.gz
+    display_name: Tarball
 ---
 This is an example config pack that you can copy to create your own.
 Please refer to the following for the metadata specification:<br>
@@ -20,3 +21,7 @@ In this case, the paths will be:<br>
 
 You may hide this config pack by removing the symlink:<br>
 `rm /opt/flight/opt/www/landing-page/default/content/config-packs/demo.md`
+
+NOTE: Disabling a config pack only prevents them from appearing on the
+landing page. They will still be accessible for download unless the
+files are also removed.

--- a/landing-page/types/headnode/content/config-packs/example.md.disabled
+++ b/landing-page/types/headnode/content/config-packs/example.md.disabled
@@ -1,5 +1,4 @@
 ---
-disabled: false # The .disabled file extension takes precedence
 title: Example Config
 short_title: Example
 subtitle: An example config pack

--- a/landing-page/types/headnode/content/config-packs/example.md.disabled
+++ b/landing-page/types/headnode/content/config-packs/example.md.disabled
@@ -24,6 +24,7 @@ In this case, the paths will be:<br>
 You may hide this config pack by removing the symlink:<br>
 `rm /opt/flight/opt/www/landing-page/default/content/config-packs/example.md`
 
-NOTE: Disabling a config pack only prevents them from appearing on the
-landing page. They will still be accessible for download unless the
-files are also removed.
+NOTE: Disabling a config pack will remove it from the landing page.  However,
+the files stored at
+`/opt/flight/usr/share/www/downloads/config-packs/<PACK_NAME>/` will remain
+accessible for download until they are removed.

--- a/landing-page/types/headnode/content/config-packs/example.md.disabled
+++ b/landing-page/types/headnode/content/config-packs/example.md.disabled
@@ -11,17 +11,19 @@ downloads:
 ---
 This is an example config pack that you can copy to create your own.
 Please refer to the following for the metadata specification:<br>
-`/opt/flight/opt/www/landing-page/default/content/config-packs/demo.md.disabled`
+`/opt/flight/opt/www/landing-page/default/content/config-packs/example.md.disabled`
 
 The listed `downloads` need to be stored in:<br>
-`/opt/flight/usr/share/www/downloads/config-packs/<PACK NAME>/`
+`/opt/flight/usr/share/www/downloads/config-packs/<PACK_NAME>/`
+
+The `PACK_NAME` is the metadata file name without the file extension.
 
 In this case, the paths will be:<br>
 `/opt/flight/usr/share/www/downloads/config-packs/example/README.md`
 `/opt/flight/usr/share/www/downloads/config-packs/example/example.tar.gz`
 
 You may hide this config pack by removing the symlink:<br>
-`rm /opt/flight/opt/www/landing-page/default/content/config-packs/demo.md`
+`rm /opt/flight/opt/www/landing-page/default/content/config-packs/example.md`
 
 NOTE: Disabling a config pack only prevents them from appearing on the
 landing page. They will still be accessible for download unless the

--- a/landing-page/types/headnode/content/enable-https.html
+++ b/landing-page/types/headnode/content/enable-https.html
@@ -1,11 +1,11 @@
-<div class="d-none https-d-block">
+<div class="d-none" data-https-d-block>
   <h2>HTTPS Enabled</h2>
   <p>
   HTTPS has been enabled for your environment.
   </p>
 </div>
 
-<div class="d-none http-d-block">
+<div class="d-none" data-http-d-block>
   <h3>How to Enable HTTPS</h3>
   <p>
   If you are reading this than HTTPS has likely been disabled. The majority of

--- a/landing-page/types/headnode/content/index.html.erb
+++ b/landing-page/types/headnode/content/index.html.erb
@@ -3,3 +3,4 @@ title: Home
 ---
 <%= blurb.compiled_content(snapshot: :pre_default) %>
 <%= apps_item.compiled_content(snapshot: :pre_default) %>
+<%= config_packs_item.compiled_content(snapshot: :pre_default) %>

--- a/landing-page/types/headnode/content/not-found.html.erb
+++ b/landing-page/types/headnode/content/not-found.html.erb
@@ -4,8 +4,8 @@
             <div class="col-md-12 text-center">
                 <span class="display-1 d-block">404</span>
                 <div class="mb-4 lead">This is not the page you are looking for!</div>
-                <div class="mb-4 lead d-none http-d-block">
-                  You may have been redirected here because HTTPs has been disabled!
+                <div class="mb-4 lead d-none" data-http-d-block>
+                  You may have been redirected here because HTTPS has been disabled!
                 </div>
                 <a href="/" class="btn btn-link">Move Along...</a>
             </div>

--- a/landing-page/types/headnode/content/not-found.html.erb
+++ b/landing-page/types/headnode/content/not-found.html.erb
@@ -4,7 +4,7 @@
             <div class="col-md-12 text-center">
                 <span class="display-1 d-block">404</span>
                 <div class="mb-4 lead">This is not the page you are looking for!</div>
-                <div class="mb-4 lead http-display-block" style="display:none">
+                <div class="mb-4 lead d-none http-d-block">
                   You may have been redirected here because HTTPs has been disabled!
                 </div>
                 <a href="/" class="btn btn-link">Move Along...</a>

--- a/landing-page/types/headnode/content/styles/app.scss
+++ b/landing-page/types/headnode/content/styles/app.scss
@@ -11,12 +11,20 @@
   grid-gap: .5rem;
 }
 
-.app-card-deck .app-card {
+.config-pack-card-deck {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, max-content));
+  grid-gap: .5rem;
+}
+
+.app-card-deck .app-card,
+.config-pack-card-deck .config-pack-card {
   margin: 0;
   min-height: 250px;
 }
 
-.app-card .card-body p:last-child {
+.app-card .card-body p:last-child,
+.config-pack-card {
     margin-bottom: 0;
 }
 

--- a/landing-page/types/headnode/layouts/app.html.erb
+++ b/landing-page/types/headnode/layouts/app.html.erb
@@ -1,4 +1,7 @@
-<div class="card app-card http-add-title http-opacify">
+<div
+  class="card app-card http-opacify"
+  data-http-add-title="Flight Web Suite requires HTTPS to be enabled"
+>
   <div class="card-body d-flex flex-column">
   <i class="fa-background fa fa-<%= @item[:fa_icon] || 'bars' %>"></i>
     <h5 class="card-title">

--- a/landing-page/types/headnode/layouts/app.html.erb
+++ b/landing-page/types/headnode/layouts/app.html.erb
@@ -1,5 +1,6 @@
 <div
-  class="card app-card http-opacify"
+  class="card app-card"
+  data-http-opacify
   data-http-add-title="Flight Web Suite requires HTTPS to be enabled"
 >
   <div class="card-body d-flex flex-column">
@@ -15,7 +16,8 @@
     <%= yield %>
     <div class="mt-auto">
       <a href="<%= @item[:path] %>"
-         class="card-link btn btn-success btn-block http-bootstrap-disable"
+         class="card-link btn btn-success btn-block"
+         data-http-bootstrap-disable
       >
         Go!
       </a>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -27,7 +27,7 @@
               # XXX: Consider making the /downloads prefix configurable
               link = File.join('/downloads', 'config-packs', package_name, link_name)
           %>
-            <a href="<%= link %>" class="list-group-item list-group-item-action" download><%= text %></a>
+            <a href="<%= link %>" class="list-group-item list-group-item-action"><%= text %></a>
           <% end %>
         </div>
       <% end %>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -31,7 +31,7 @@
               <a
                 href="<%= link %>"
                 rel="noopener"
-                class="http-strike-disable"
+                data-http-strike-disable
                 data-http-add-title="Config packs require HTTPS to be enabled"
               >
                 <%= text %>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -1,6 +1,5 @@
 <div class="card config-pack-card">
   <div class="card-body d-flex flex-column">
-  <i class="fa-background fa fa-<%= @item[:fa_icon] || 'bars' %>"></i>
     <h5 class="card-title">
       <%= @item[:title] %>
     </h5>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -19,12 +19,12 @@
         <div class="list-group">
           <%
             @item[:downloads].each do |parts|
-              parts = Array[parts] unless parts.is_a?(Array)
-              text = parts.first
+              file_name = parts[:file_name]
+              raise "Each downloads entry requires a 'file_name'" unless file_name
+              text = parts.fetch(:display_name, file_name)
               package_name = File.basename(@item.identifier, '.*')
-              link_name = (parts.length > 1 ? parts[1] : text)
               # XXX: Consider making the /downloads prefix configurable
-              link = File.join('/downloads', 'config-packs', package_name, link_name)
+              link = File.join('/downloads', 'config-packs', package_name, file_name)
           %>
             <span class="list-group-item list-group-item-action">
               <a href="<%= link %>" rel="noopener"><%= text %></a>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -14,16 +14,21 @@
       <h6 class='card-subtitle mb-2 text-muted'>
         Downloads
       </h6>
-      <% @item[:configs].each do |parts| %>
-        <%
-          parts = Array[parts] unless parts.is_a?(Array)
-          text = parts.first
-          package_name = File.basename(@item.identifier, '.*')
-          link_name = (parts.length > 1 ? parts[1] : text)
-          link = File.join('downloads', 'config-packs', package_name, link_name)
-        %>
-      <a href="<%= link %>" class="link-primary" download><%= text %></a><br>
-      <% end %>
+      <% if @item[:downloads].nil? %>
+        <p><em>Nothing to see here...</em></p>
+      <% else
+            @item[:downloads].each do |parts|
+              parts = Array[parts] unless parts.is_a?(Array)
+              text = parts.first
+              package_name = File.basename(@item.identifier, '.*')
+              link_name = (parts.length > 1 ? parts[1] : text)
+              # XXX: Consider making the /downloads prefix configurable
+              link = File.join('/downloads', 'config-packs', package_name, link_name)
+      %>
+        <a href="<%= link %>" class="link-primary" download><%= text %></a><br>
+      <%    end
+         end
+      %>
     </div>
   </div>
 </div>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -27,6 +27,7 @@
               link = File.join('/downloads', 'config-packs', package_name, file_name)
           %>
             <span class="list-group-item list-group-item-action">
+              <i class="fa fa-<%= parts.fetch(:fa_icon, 'file-o') %> mr-1"></i>
               <a href="<%= link %>" rel="noopener"><%= text %></a>
             </span>
           <% end %>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -16,7 +16,9 @@
       </h6>
       <% if @item[:downloads].nil? %>
         <p><em>Nothing to see here...</em></p>
-      <% else
+      <% else %>
+        <div class="list-group">
+          <%
             @item[:downloads].each do |parts|
               parts = Array[parts] unless parts.is_a?(Array)
               text = parts.first
@@ -24,11 +26,11 @@
               link_name = (parts.length > 1 ? parts[1] : text)
               # XXX: Consider making the /downloads prefix configurable
               link = File.join('/downloads', 'config-packs', package_name, link_name)
-      %>
-        <a href="<%= link %>" class="link-primary" download><%= text %></a><br>
-      <%    end
-         end
-      %>
+          %>
+            <a href="<%= link %>" class="list-group-item list-group-item-action" download><%= text %></a>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -28,7 +28,14 @@
           %>
             <span class="list-group-item list-group-item-action">
               <i class="fa fa-<%= parts.fetch(:fa_icon, 'file-o') %> mr-1"></i>
-              <a href="<%= link %>" rel="noopener" class="http-strike-disable http-add-title"><%= text %></a>
+              <a
+                href="<%= link %>"
+                rel="noopener"
+                class="http-strike-disable"
+                data-http-add-title="Config packs require HTTPS to be enabled"
+              >
+                <%= text %>
+              </a>
             </span>
           <% end %>
         </div>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -1,0 +1,19 @@
+<div class="card config-pack-card">
+  <div class="card-body d-flex flex-column">
+  <i class="fa-background fa fa-<%= @item[:fa_icon] || 'bars' %>"></i>
+    <h5 class="card-title">
+      <%= @item[:title] %>
+    </h5>
+    <% if @item[:subtitle] %>
+      <h6 class="card-subtitle mb-2 text-muted">
+        <%= @item[:subtitle] %>
+      </h6>
+    <% end %>
+    <%= yield %>
+    <div class="mt-auto">
+      <a href="<%= @item[:path] %>" class="card-link btn btn-success btn-block">
+        Go!
+      </a>
+    </div>
+  </div>
+</div>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -27,7 +27,9 @@
               # XXX: Consider making the /downloads prefix configurable
               link = File.join('/downloads', 'config-packs', package_name, link_name)
           %>
-            <a href="<%= link %>" class="list-group-item list-group-item-action"><%= text %></a>
+            <span class="list-group-item list-group-item-action">
+              <a href="<%= link %>" rel="noopener"><%= text %></a>
+            </span>
           <% end %>
         </div>
       <% end %>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -28,7 +28,7 @@
           %>
             <span class="list-group-item list-group-item-action">
               <i class="fa fa-<%= parts.fetch(:fa_icon, 'file-o') %> mr-1"></i>
-              <a href="<%= link %>" rel="noopener"><%= text %></a>
+              <a href="<%= link %>" rel="noopener" class="http-strike-disable http-add-title"><%= text %></a>
             </span>
           <% end %>
         </div>

--- a/landing-page/types/headnode/layouts/config-pack.html.erb
+++ b/landing-page/types/headnode/layouts/config-pack.html.erb
@@ -11,9 +11,19 @@
     <% end %>
     <%= yield %>
     <div class="mt-auto">
-      <a href="<%= @item[:path] %>" class="card-link btn btn-success btn-block">
-        Go!
-      </a>
+      <h6 class='card-subtitle mb-2 text-muted'>
+        Downloads
+      </h6>
+      <% @item[:configs].each do |parts| %>
+        <%
+          parts = Array[parts] unless parts.is_a?(Array)
+          text = parts.first
+          package_name = File.basename(@item.identifier, '.*')
+          link_name = (parts.length > 1 ? parts[1] : text)
+          link = File.join('downloads', 'config-packs', package_name, link_name)
+        %>
+      <a href="<%= link %>" class="link-primary" download><%= text %></a><br>
+      <% end %>
     </div>
   </div>
 </div>

--- a/landing-page/types/headnode/layouts/default.html.erb
+++ b/landing-page/types/headnode/layouts/default.html.erb
@@ -44,24 +44,20 @@
           ref.title = title;
         });
 
-        document.querySelectorAll(".http-opacify").forEach((ref) => {
-          ref.classList.remove("http-opacify");
+        document.querySelectorAll("[data-http-opacify]").forEach((ref) => {
           ref.classList.add("http-opacified");
         });
 
-        document.querySelectorAll(".http-bootstrap-disable").forEach((ref) => {
-          ref.classList.remove("http-bootstrap-disable");
+        document.querySelectorAll("[data-http-bootstrap-disable]").forEach((ref) => {
           ref.classList.add("disabled", "http-bootstrap-disabled");
         });
 
-        document.querySelectorAll(".http-strike-disable").forEach((ref) => {
+        document.querySelectorAll("[data-http-strike-disable]").forEach((ref) => {
           ref.href = "javascript:void(0)";
-          ref.classList.remove("http-strike-disable");
           ref.classList.add("http-strike-disabled", "text-muted");
         });
 
-        document.querySelectorAll('.http-d-block').forEach((ref) => {
-          ref.classList.remove("http-d-block");
+        document.querySelectorAll('[data-http-d-block]').forEach((ref) => {
           ref.classList.add("d-block");
         });
       });
@@ -70,8 +66,7 @@
       // The site is being accessed over HTTPS.  Make it obvious that the web
       // suite will work.
       window.addEventListener('load', (_) => {
-        document.querySelectorAll('.https-d-block').forEach((ref) => {
-          ref.classList.remove("https-d-block");
+        document.querySelectorAll('[data-https-d-block]').forEach((ref) => {
           ref.classList.add("d-block");
         });
       });

--- a/landing-page/types/headnode/layouts/default.html.erb
+++ b/landing-page/types/headnode/layouts/default.html.erb
@@ -39,9 +39,9 @@
       // suite won't work and display content to explain how to enable HTTPS.
       window.addEventListener('load', (_) => {
         // Disable links to Flight Web Suite when accessed over HTTP.
-        document.querySelectorAll(".http-add-title").forEach((ref) => {
-          ref.classList.remove("http-add-title");
-          ref.title = "Flight Web Suite requires HTTPS to be enabled"
+        document.querySelectorAll("[data-http-add-title]").forEach((ref) => {
+          title = ref.dataset["httpAddTitle"] || "HTTPS needs to be enabled";
+          ref.title = title;
         });
 
         document.querySelectorAll(".http-opacify").forEach((ref) => {

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -60,7 +60,7 @@
                       class="nav-link nav-menu-button"
                       href="/config-packs"
                   >
-                      Tool Packs
+                      Config Packs
                   </a>
               </li>
             <% end %>

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -48,9 +48,19 @@
               <li class="nav-item">
                   <a
                       class="nav-link nav-menu-button"
-                      href="#apps"
+                      href="/apps"
                   >
                       Web Suite
+                  </a>
+              </li>
+            <% end %>
+            <% unless config_pack_items.empty? %>
+              <li class="nav-item">
+                  <a
+                      class="nav-link nav-menu-button"
+                      href="/config-packs"
+                  >
+                      Tool Packs
                   </a>
               </li>
             <% end %>

--- a/landing-page/types/headnode/layouts/sidebar.html.erb
+++ b/landing-page/types/headnode/layouts/sidebar.html.erb
@@ -48,16 +48,5 @@
         <% end %>
       </ul>
     <% end %>
-
-    <% if !app_items.empty? %>
-      <h2>Tool Packs</h2>
-      <ul class="w-100">
-        <% config_pack_items.each do |app| %>
-          <li>
-            <%= link_to(app[:short_title] || app[:title], app[:path]) %>
-          </li>
-        <% end %>
-      </ul>
-    <% end %>
   </div>
 </aside>

--- a/landing-page/types/headnode/layouts/sidebar.html.erb
+++ b/landing-page/types/headnode/layouts/sidebar.html.erb
@@ -41,7 +41,8 @@
               link_to(
                 app[:short_title] || app[:title],
                 app[:path],
-                class: "http-strike-disable http-add-title"
+                class: "http-strike-disable",
+                "data-http-add-title" => "Flight Web Suite requires HTTPS to be enabled",
               )
             %>
           </li>

--- a/landing-page/types/headnode/layouts/sidebar.html.erb
+++ b/landing-page/types/headnode/layouts/sidebar.html.erb
@@ -48,5 +48,16 @@
         <% end %>
       </ul>
     <% end %>
+
+    <% if !app_items.empty? %>
+      <h2>Tool Packs</h2>
+      <ul class="w-100">
+        <% config_pack_items.each do |app| %>
+          <li>
+            <%= link_to(app[:short_title] || app[:title], app[:path]) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 </aside>

--- a/landing-page/types/headnode/layouts/sidebar.html.erb
+++ b/landing-page/types/headnode/layouts/sidebar.html.erb
@@ -41,7 +41,7 @@
               link_to(
                 app[:short_title] || app[:title],
                 app[:path],
-                class: "http-strike-disable",
+                "data-http-strike-disable" => "",
                 "data-http-add-title" => "Flight Web Suite requires HTTPS to be enabled",
               )
             %>


### PR DESCRIPTION
These config packs are based on the web applications but are for a slightly different purpose. `config-packs` have a list of links (`downloads`) instead of a web-application page.

The `config-packs` store there metadata file within: `/content/config-packs/<pack-name>.md`. The `pack-name` is assumed to be unique and nicely formattable into a URL.

The metadata file syntax is:

```
---
title: Demo config pack
short_title: Config pack
subtitle: Access the demo config pack
downloads:
  - <filename>
  - [<humanized-name>, <filename>]
---
Lorem ipsum dolor sit amet, consectetur adipiscing elit. ...
```

The landing page is not responsible for hosting the config files themselves. This is to allow the configs to be updated without the landing page being recompiled. Instead they rely on an external service (`nginx`) to serve content on its behalf.

By convention, the files need to be hosted at:
`/downloads/config-packs/<pack-name>/<filename>`