### PR TITLE
Config pack documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,13 @@ bundle exec nanoc compile
 
 ## Config packs
 
-Config packs allow an admin to make a set of significant files/documents
-available to users on the landing page. A good use case for a config pack
-would be one that contains VPN config and keys to allow a user to connect
-to the cluster from home.
+Config packs are a mechanism allowing the cluster administrator to provide
+packs of files for download from the landing page.  This is similar to an FTP
+site but easier for many users to navigate.
+
+An example use case for a config pack would be one containing a VPN
+configuration, keys and instructions allowing a user to connect to the cluster
+from home.
 
 An example config pack is included with Flight Landing Page, although it
 is disabled upon installation. Its location is:
@@ -194,16 +197,14 @@ When a config pack has been created/modified, the landing page must be recompile
 ### Downloadable files
 
 As described in `example.md.disabled`, files listed in the config pack need to
-be stored in:
-`/opt/flight/usr/share/www/downloaded/config-packs/<PACK_NAME>/`
-
+be stored in `/opt/flight/usr/share/www/downloaded/config-packs/<PACK_NAME>/`
 where `<PACK_NAME>` is the config pack file without the file extension.
 
 The `file_name` key in the config pack accepts two extra keys: `display_name`
 and `fa_icon`. `display_name` is the name that the file will be given on the
 landing page; `fa_icon` allows you to set a valid Font Awesome (v4.7.0) icon
 to be displayed next to the filename (the `file-o` icon is chosen if one
-isn't specified by the user).
+isn't specified in the config pack).
 
 ## Operation
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,47 @@ cd flight-landing-page/landing-page
 bundle exec nanoc compile
 ```
 
+## Config packs
+
+Config packs allow an admin to make a set of significant files/documents
+available to users on the landing page. A good use case for a config pack
+would be one that contains VPN config and keys to allow a user to connect
+to the cluster from home.
+
+An example config pack is included with Flight Landing Page, although it
+is disabled upon installation. Its location is:
+
+_via Flight Runway_
+```
+/opt/flight/opt/www/landing-page/default/content/config-packs/example.md.disabled
+```
+
+_via source_
+```
+flight-landing-page/landing-page/default/content/config-packs/example.md.disabled
+```
+
+The YAML structure present at the top of the example config pack contains some
+basic title keys that are displayed on the landing page (the text following the
+YAML structure is also displayed there). The `downloads` key in the YAML
+structure specifies the files that are included in the config pack.
+
+When a config pack has been created/modified, the landing page must be recompiled.
+
+### Downloadable files
+
+As described in `example.md.disabled`, files listed in the config pack need to
+be stored in:
+`/opt/flight/usr/share/www/downloaded/config-packs/<PACK_NAME>/`
+
+where `<PACK_NAME>` is the config pack file without the file extension.
+
+The `file_name` key in the config pack accepts two extra keys: `display_name`
+and `fa_icon`. `display_name` is the name that the file will be given on the
+landing page; `fa_icon` allows you to set a valid Font Awesome (v4.7.0) icon
+to be displayed next to the filename (the `file-o` icon is chosen if one
+isn't specified by the user).
+
 ## Operation
 
 Once compiled (see above), the landing page is a set of static HTML files to

--- a/landing-page/types/headnode/content/config-packs/example.md.disabled
+++ b/landing-page/types/headnode/content/config-packs/example.md.disabled
@@ -21,8 +21,15 @@ In this case, the paths will be:<br>
 `/opt/flight/usr/share/www/downloads/config-packs/example/README.md`
 `/opt/flight/usr/share/www/downloads/config-packs/example/example.tar.gz`
 
-You may hide this config pack by removing the symlink:<br>
-`rm /opt/flight/opt/www/landing-page/default/content/config-packs/example.md`
+You may enable this config pack by creating a symlink and recompiling the landing page:<br>
+```
+ln -s /opt/flight/opt/www/landing-page/default/content/config-packs/example.md.disabled
+      /opt/flight/opt/www/landing-page/default/content/config-packs/example.md
+```
+
+```
+flight landing-page compile
+```
 
 NOTE: Disabling a config pack will remove it from the landing page.  However,
 the files stored at


### PR DESCRIPTION
This PR aims to add documentation to the README regarding the use of config packs. It also updates the `exampled.md.disabled` copy to describe enabling the default config pack instead of hiding it (following the changes made to it in [the Omnibus Builder](https://github.com/openflighthpc/openflight-omnibus-builder/pull/182))