### PR TITLE
Add key to branding JSON for sign-in modal text

### DIFF
--- a/landing-page/types/alces-branding/content/data/branding.yaml
+++ b/landing-page/types/alces-branding/content/data/branding.yaml
@@ -63,6 +63,14 @@ sidebar:
   websuite:
     show: true
 
+signInModal:
+  # Optional text for the sign-in form modal. If not given, text appropriate
+  # to OpenflightHPC will be used.
+  text: |
+    Sign in to your Flight Direct account. You'll need your account username
+    and password. Contact your HPC administrator if you don't have these
+    details or need a reminder.
+
 landingpage:
   dashboard:
     # Optional logo for the landing page environment page (aka dashboard).

--- a/landing-page/types/headnode/content/data/branding.yaml
+++ b/landing-page/types/headnode/content/data/branding.yaml
@@ -62,6 +62,11 @@ sidebar:
   websuite:
     show: true
 
+# signInModal:
+#   # Optional text for the sign-in form modal. If not given, text appropriate
+#   # to OpenflightHPC will be used.
+#   text: ""
+
 # landingpage:
 #   dashboard:
 #     # Optional logo for the landing page environment page (aka dashboard).
@@ -79,9 +84,6 @@ sidebar:
 #       text: ""
 
 # apps:
-#   signInModal:
-#     # Text for the sign-in form modal. If not given, the modal will be blank.
-#     text: "Sign in to your Flight Direct account. You'll need your account username and password. Contact your HPC administrator if you don't have these details or need a reminder."
 #   dashboard:
 #     # Optional logo for the webapp dashboards.
 #     # Defaults to the OpenflightHPC logo if not provided.

--- a/landing-page/types/headnode/content/data/branding.yaml
+++ b/landing-page/types/headnode/content/data/branding.yaml
@@ -79,6 +79,9 @@ sidebar:
 #       text: ""
 
 # apps:
+#   signInModal:
+#     # Text for the sign-in form modal. If not given, the modal will be blank.
+#     text: "Sign in to your Flight Direct account. You'll need your account username and password. Contact your HPC administrator if you don't have these details or need a reminder."
 #   dashboard:
 #     # Optional logo for the webapp dashboards.
 #     # Defaults to the OpenflightHPC logo if not provided.


### PR DESCRIPTION
This PR adds data to the `branding.json` file for the `headnode` type to be used by the [changes](https://github.com/openflighthpc/flight-webapp-components/pull/5) made in `flight-webapp-components`. The new data is to be used to customise the copy used on the sign-in modal.