### PR TITLE
Modify 'web suite' link to be a dropdown menu containing apps

### DIFF
--- a/landing-page/types/alces-branding/content/styles/branding.css
+++ b/landing-page/types/alces-branding/content/styles/branding.css
@@ -21,6 +21,11 @@ body {
 .navbar a.nav.dropdown-item:hover {
     background-color: #586775;
 }
+.navbar .dropdown-toggle {
+    color: white !important;
+    display: flex;
+    align-items: center;
+}
 
 .navbar-brand { }
 .navbar li {

--- a/landing-page/types/alces-branding/content/styles/branding.css
+++ b/landing-page/types/alces-branding/content/styles/branding.css
@@ -21,7 +21,8 @@ body {
 .navbar .dropdown-item {
     color: white;
 }
-.navbar a.dropdown-item:hover {
+.navbar a.dropdown-item:hover,
+.navbar a.dropdown-item:focus {
     background-color: #586775;
 }
 .navbar .dropdown-toggle {

--- a/landing-page/types/alces-branding/content/styles/branding.css
+++ b/landing-page/types/alces-branding/content/styles/branding.css
@@ -40,6 +40,12 @@ body {
     font-weight: bold;
     font-size: larger;
 }
+.navbar .dropdown .btn-group .nav-menu-button {
+    padding-right: 0;
+}
+.navbar .dropdown .btn-group .dropdown-toggle-split {
+    padding-right: 24px;
+}
 
 .navbar.brandbar .navbar-nav-container,
 .navbar.productbar .navbar-nav-container {
@@ -54,6 +60,10 @@ body {
     border-right-style: dotted;
     border-right-color: rgb(88, 103, 117);
     padding: 8px 24px 8px 24px;
+}
+.navbar .navbar-nav .dropdown-item.nav-link {
+    padding-left: 8px;
+    padding-right: 8px;
 }
 
 .navbar .navbar-nav #account-menu {

--- a/landing-page/types/alces-branding/content/styles/branding.css
+++ b/landing-page/types/alces-branding/content/styles/branding.css
@@ -18,6 +18,9 @@ body {
 .navbar .dropdown-menu {
     background-color: rgba(0, 0, 0, 0.9);
 }
+.navbar .dropdown-item:hover span {
+    color: black;
+}
 .navbar a.nav.dropdown-item:hover {
     background-color: #586775;
 }

--- a/landing-page/types/alces-branding/content/styles/branding.css
+++ b/landing-page/types/alces-branding/content/styles/branding.css
@@ -66,10 +66,6 @@ body {
     font-weight: normal;
     padding: 8px 24px 8px 24px;
 }
-.navbar .navbar-nav .dropdown-item.nav-link {
-    padding-left: 8px;
-    padding-right: 8px;
-}
 
 .navbar .navbar-nav #account-menu {
     text-transform: none;

--- a/landing-page/types/alces-branding/content/styles/branding.css
+++ b/landing-page/types/alces-branding/content/styles/branding.css
@@ -51,14 +51,16 @@ body {
 .navbar.productbar .navbar-nav-container {
     justify-content: end;
 }
+.navbar .navbar-nav .nav-item {
+    border-right-width: 1px;
+    border-right-style: dotted;
+    border-right-color: rgb(88, 103, 117);
+}
 .navbar .navbar-nav .nav-link {
     color: white !important;
     font-size: 12px;
     text-transform: uppercase;
     font-weight: normal;
-    border-right-width: 1px;
-    border-right-style: dotted;
-    border-right-color: rgb(88, 103, 117);
     padding: 8px 24px 8px 24px;
 }
 .navbar .navbar-nav .dropdown-item.nav-link {
@@ -70,11 +72,11 @@ body {
     text-transform: none;
 }
 
-.App .navbar .navbar-nav .nav-item:last-child .nav-link {
+.App .navbar .navbar-nav .nav-item:last-child {
     border-right-style: dotted;
 }
 
-.navbar .navbar-nav .nav-item:last-child .nav-link {
+.navbar .navbar-nav .nav-item:last-child {
     border-right-style: none;
 }
 

--- a/landing-page/types/alces-branding/content/styles/branding.css
+++ b/landing-page/types/alces-branding/content/styles/branding.css
@@ -18,6 +18,9 @@ body {
 .navbar .dropdown-menu {
     background-color: rgba(0, 0, 0, 0.9);
 }
+.navbar .dropdown-item {
+    color: white;
+}
 .navbar .dropdown-item:hover span {
     color: black;
 }

--- a/landing-page/types/alces-branding/content/styles/branding.css
+++ b/landing-page/types/alces-branding/content/styles/branding.css
@@ -21,10 +21,7 @@ body {
 .navbar .dropdown-item {
     color: white;
 }
-.navbar .dropdown-item:hover span {
-    color: black;
-}
-.navbar a.nav.dropdown-item:hover {
+.navbar a.dropdown-item:hover {
     background-color: #586775;
 }
 .navbar .dropdown-toggle {

--- a/landing-page/types/green-theme/content/styles/branding.css
+++ b/landing-page/types/green-theme/content/styles/branding.css
@@ -58,6 +58,9 @@ body {
     font-weight: bold;
     font-size: larger;
 }
+.navbar .dropdown .btn-group .nav-menu-button {
+    padding-right: 0;
+}
 
 /*------------------------------------------------
  * Product bar branding

--- a/landing-page/types/green-theme/content/styles/branding.css
+++ b/landing-page/types/green-theme/content/styles/branding.css
@@ -7,6 +7,10 @@ body {
 .sidenav {
     margin-top: 1.5rem;
 }
+.sidenav .fa-solid {
+    padding-right: 2px;
+    display: inline-block;
+}
 
 /*------------------------------------------------
  * Navbar and brandbar branding
@@ -36,11 +40,25 @@ body {
 .branding-brandbar-text { }
 .branding-brandbar-logo img { }
 
+.navbar.brandbar .navbar-nav-container {
+    justify-content: space-between;
+}
 .navbar {
     border-bottom: 1px solid #3f4245;
 }
 .navbar-light .navbar-nav .nav-menu-text:hover {
     color: rgba(0,0,0,.5);
+}
+.navbar .dropdown-toggle {
+    display:flex;
+    align-items: center;
+}
+.navbar .dropdown-item {
+    font-size: 16px;
+    font-weight: normal;
+}
+.navbar .fa-solid {
+    display: inline-block;
 }
 .navbar-brand {
     padding-left: 4rem;
@@ -84,6 +102,13 @@ body {
 .productbar .nav-item.active,
 .productbar .nav-item .nav-link.active {
     /* color: #fff; */
+}
+
+.App .brandbar.brandbar-combined {
+    display: none;
+}
+.App .brandbar:not(.brandbar-combined),
+.App .productbar {
 }
 
 /*------------------------------------------------
@@ -160,6 +185,12 @@ img.logo {
 .branding-landingpage-dashboard-logo-wrapper { }
 img.branding-landingpage-dashboard-logo { }
 
+.blurb .powered-by {
+    color: #999;
+    font-size: 18px;
+    text-align: center;
+}
+
 /* -----------------------------------------------
  * App branding
  * ----------------------------------------------- */
@@ -174,3 +205,20 @@ img.branding-landingpage-dashboard-logo { }
 .branding-apps-dashboard-logo-wrapper { }
 img.branding-apps-dashboard-logo { }
 
+
+/* -----------------------------------------------
+ * Apps full screen and zen-mode styles
+ * ----------------------------------------------- */
+
+.App .fullscreen-content {
+    /* Subtract header, centernav margin, card header, card border, #main
+     * bottom margin, footer, extra to make things nicer. */
+    height: calc( 100vh - ( 102px + 41px ) - 24px - 2px - 56px - 16px - 60px - 0px );
+}
+
+html:fullscreen .fullscreen-content,
+body.zen-mode .fullscreen-content {
+    /* Subtract card header, card border, #main top and bottom margins.
+     * extra to make things nicer. */
+    height: calc( 100vh - 56px - 2px - 10px - 10px - 0px );
+}

--- a/landing-page/types/headnode/content/styles/branding.css
+++ b/landing-page/types/headnode/content/styles/branding.css
@@ -40,6 +40,9 @@ body {
     font-size: 16px;
     font-weight: normal;
 }
+.navbar .fa-solid {
+    display: inline-block;
+}
 .navbar-brand {
     padding-left: 4rem;
 }

--- a/landing-page/types/headnode/content/styles/branding.css
+++ b/landing-page/types/headnode/content/styles/branding.css
@@ -38,6 +38,7 @@ body {
 }
 .navbar .dropdown-item {
     font-size: 16px;
+    font-weight: normal;
 }
 .navbar-brand {
     padding-left: 4rem;

--- a/landing-page/types/headnode/content/styles/branding.css
+++ b/landing-page/types/headnode/content/styles/branding.css
@@ -9,7 +9,7 @@ body {
 }
 .sidenav .fa-solid {
     padding-right: 2px;
-    font-size: 12px;
+//    font-size: 12px;
     display: inline-block;
 }
 

--- a/landing-page/types/headnode/content/styles/branding.css
+++ b/landing-page/types/headnode/content/styles/branding.css
@@ -9,7 +9,6 @@ body {
 }
 .sidenav .fa-solid {
     padding-right: 2px;
-//    font-size: 12px;
     display: inline-block;
 }
 

--- a/landing-page/types/headnode/content/styles/branding.css
+++ b/landing-page/types/headnode/content/styles/branding.css
@@ -64,6 +64,9 @@ body {
     font-weight: bold;
     font-size: larger;
 }
+.navbar .dropdown .btn-group .nav-menu-button {
+    padding-right: 0;
+}
 
 /*------------------------------------------------
  * Product bar branding

--- a/landing-page/types/headnode/content/styles/branding.css
+++ b/landing-page/types/headnode/content/styles/branding.css
@@ -15,6 +15,8 @@ body {
 /* Useful classes */
 .navbar { }
 .navbar .navbar-nav .nav-link { }
+.navbar .dropdown-menu {}
+.navbar .dropdown-item {}
 .navbar-brand { }
 .branding-brandbar-wrapper { }
 .branding-brandbar-text-wrapper { }
@@ -29,6 +31,13 @@ body {
 }
 .navbar-light .navbar-nav .nav-menu-text:hover {
     color: rgba(0,0,0,.5);
+}
+.navbar .dropdown-toggle {
+    display:flex;
+    align-items: center;
+}
+.navbar .dropdown-item {
+    font-size: 16px;
 }
 .navbar-brand {
     padding-left: 4rem;

--- a/landing-page/types/headnode/content/styles/branding.css
+++ b/landing-page/types/headnode/content/styles/branding.css
@@ -7,6 +7,11 @@ body {
 .sidenav {
     margin-top: 1.5rem;
 }
+.sidenav .fa-solid {
+    padding-right: 2px;
+    font-size: 12px;
+    display: inline-block;
+}
 
 /*------------------------------------------------
  * Navbar and brandbar branding

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -65,7 +65,7 @@
                   <div class="btn-group">
                       <a
                           class="nav-link nav-menu-button"
-                          href="<%= prefix_url("/apps") %>/apps"
+                          href="<%= prefix_url("/apps") %>"
                       >
                           <%=
                             branding('brandbar.apps_link.text') ||

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -86,7 +86,7 @@
                           <% app_items.each do |app| %>
                               <a
                                   href="<%= app[:path] %>"
-                                  class="dropdown-item nav-link nav-menu-button"
+                                  class="dropdown-item"
                               >
 				  <span class="fa fa-solid fa-fw fa-<%= app[:fa_icon] %>"></span>
 				  <span class="title"><%= app[:short_title] || app[:title] %></span>

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -62,15 +62,37 @@
 
             <% unless app_items.empty? %>
               <li class="nav-item">
-                  <a
-                      class="nav-link nav-menu-button"
-                      href="<%= prefix_url("/apps") %>"
-                  >
-                      <%=
-                        branding('brandbar.apps_link.text') ||
-                          'Web Suite'
-                        %>
-                  </a>
+                  <div class="btn-group">
+                      <a
+                          class="nav-link nav-menu-button"
+                          href="<%= prefix_url("/apps") %>/apps"
+                      >
+                          <%=
+                            branding('brandbar.apps_link.text') ||
+                              'Web Suite'
+                            %>
+
+                      </a>
+                      <a
+                          type="button"
+                          class="dropdown-toggle dropdown-toggle-split"
+                          data-toggle="dropdown"
+                          aria-haspopup="true"
+                          aria-expanded="false"
+                      >
+                          <span class="sr-only">Toggle Dropdown</span>
+                      </a>
+                      <div class="dropdown-menu">
+                          <% app_items.each do |app| %>
+                              <a
+                                  href="<%= app[:path] %>"
+                                  class="dropdown-item nav-link nav-menu-button"
+                              >
+                                  <%= app[:short_title] || app[:title] %>
+                              </a>
+                          <% end %>
+                      </div>
+                  </div>
               </li>
             <% end %>
             <% unless config_pack_items.empty? %>

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -88,7 +88,8 @@
                                   href="<%= app[:path] %>"
                                   class="dropdown-item nav-link nav-menu-button"
                               >
-                                  <%= app[:short_title] || app[:title] %>
+				  <span class="fa-solid fa-fw fa-<%= app[:fa_icon] %>"></span>
+				  <span class="title"><%= app[:short_title] || app[:title] %></span>
                               </a>
                           <% end %>
                       </div>

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -82,7 +82,7 @@
                       >
                           <span class="sr-only">Toggle Dropdown</span>
                       </a>
-                      <div class="dropdown-menu">
+                      <div class="dropdown-menu dropdown-menu-right">
                           <% app_items.each do |app| %>
                               <a
                                   href="<%= app[:path] %>"

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -88,7 +88,7 @@
                                   href="<%= app[:path] %>"
                                   class="dropdown-item nav-link nav-menu-button"
                               >
-				  <span class="fa-solid fa-fw fa-<%= app[:fa_icon] %>"></span>
+				  <span class="fa fa-solid fa-fw fa-<%= app[:fa_icon] %>"></span>
 				  <span class="title"><%= app[:short_title] || app[:title] %></span>
                               </a>
                           <% end %>

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -61,7 +61,7 @@
             </li>
 
             <% unless app_items.empty? %>
-              <li class="nav-item">
+              <li class="nav-item dropdown">
                   <div class="btn-group">
                       <a
                           class="nav-link nav-menu-button"

--- a/landing-page/types/headnode/layouts/sidebar.html.erb
+++ b/landing-page/types/headnode/layouts/sidebar.html.erb
@@ -36,10 +36,12 @@
       <h2>Quick Access</h2>
       <ul class="w-100">
         <% app_items.each do |app| %>
+          <% icon = "<span class=\"fa-solid fa-fw fa-#{app[:fa_icon]}\"></span>" %>
+          <% title = "<span class=\"title\">#{app[:short_title] || app[:title]}></span>" %>
           <li>
             <%=
               link_to(
-                app[:short_title] || app[:title],
+                icon + title,
                 prefix_url(app[:path]),
                 "data-http-strike-disable" => "",
                 "data-http-add-title" => "Flight Web Suite requires HTTPS to be enabled",

--- a/landing-page/types/headnode/layouts/sidebar.html.erb
+++ b/landing-page/types/headnode/layouts/sidebar.html.erb
@@ -37,7 +37,7 @@
       <ul class="w-100">
         <% app_items.each do |app| %>
           <% icon = "<span class=\"fa fa-solid fa-fw fa-#{app[:fa_icon]}\"></span>" %>
-          <% title = "<span class=\"title\">#{app[:short_title] || app[:title]}></span>" %>
+          <% title = "<span class=\"title\">#{app[:short_title] || app[:title]}</span>" %>
           <li>
             <%=
               link_to(

--- a/landing-page/types/headnode/layouts/sidebar.html.erb
+++ b/landing-page/types/headnode/layouts/sidebar.html.erb
@@ -36,7 +36,7 @@
       <h2>Quick Access</h2>
       <ul class="w-100">
         <% app_items.each do |app| %>
-          <% icon = "<span class=\"fa-solid fa-fw fa-#{app[:fa_icon]}\"></span>" %>
+          <% icon = "<span class=\"fa fa-solid fa-fw fa-#{app[:fa_icon]}\"></span>" %>
           <% title = "<span class=\"title\">#{app[:short_title] || app[:title]}></span>" %>
           <li>
             <%=

--- a/landing-page/types/red-theme/content/styles/branding.css
+++ b/landing-page/types/red-theme/content/styles/branding.css
@@ -7,6 +7,10 @@ body {
 .sidenav {
     margin-top: 1.5rem;
 }
+.sidenav .fa-solid {
+    padding-right: 2px;
+    display: inline-block;
+}
 
 /*------------------------------------------------
  * Navbar and brandbar branding
@@ -35,11 +39,25 @@ body {
 .branding-brandbar-text { }
 .branding-brandbar-logo img { }
 
+.navbar.brandbar .navbar-nav-container {
+    justify-content: space-between;
+}
 .navbar {
     border-bottom: 1px solid #ebf8e1;
 }
 .navbar-light .navbar-nav .nav-menu-text:hover {
     color: rgba(0,0,0,.5);
+}
+.navbar .dropdown-toggle {
+    display:flex;
+    align-items: center;
+}
+.navbar .dropdown-item {
+    font-size: 16px;
+    font-weight: normal;
+}
+.navbar .fa-solid {
+    display: inline-block;
 }
 .navbar-brand {
     padding-left: 4rem;
@@ -83,6 +101,13 @@ body {
 .productbar .nav-item.active,
 .productbar .nav-item .nav-link.active {
     /* color: #fff; */
+}
+
+.App .brandbar.brandbar-combined {
+    display: none;
+}
+.App .brandbar:not(.brandbar-combined),
+.App .productbar {
 }
 
 /*------------------------------------------------
@@ -154,6 +179,12 @@ img.logo {
 .branding-landingpage-dashboard-logo-wrapper { }
 img.branding-landingpage-dashboard-logo { }
 
+.blurb .powered-by {
+    color: #999;
+    font-size: 18px;
+    text-align: center;
+}
+
 /* -----------------------------------------------
  * App branding
  * ----------------------------------------------- */
@@ -168,3 +199,20 @@ img.branding-landingpage-dashboard-logo { }
 .branding-apps-dashboard-logo-wrapper { }
 img.branding-apps-dashboard-logo { }
 
+
+/* -----------------------------------------------
+ * Apps full screen and zen-mode styles
+ * ----------------------------------------------- */
+
+.App .fullscreen-content {
+    /* Subtract header, centernav margin, card header, card border, #main
+     * bottom margin, footer, extra to make things nicer. */
+    height: calc( 100vh - ( 102px + 41px ) - 24px - 2px - 56px - 16px - 60px - 0px );
+}
+
+html:fullscreen .fullscreen-content,
+body.zen-mode .fullscreen-content {
+    /* Subtract card header, card border, #main top and bottom margins.
+     * extra to make things nicer. */
+    height: calc( 100vh - 56px - 2px - 10px - 10px - 0px );
+}

--- a/landing-page/types/red-theme/content/styles/branding.css
+++ b/landing-page/types/red-theme/content/styles/branding.css
@@ -57,6 +57,9 @@ body {
     font-weight: bold;
     font-size: larger;
 }
+.navbar .dropdown .btn-group .nav-menu-button {
+    padding-right: 0;
+}
 
 /*------------------------------------------------
  * Product bar branding


### PR DESCRIPTION
This PR introduces a change to the landing page navbar. The conditionally used `Web Suite` button is now a split dropdown button. The old button functionality remains the same, but it is now followed by a dropdown button listing the available webapps.