### PR TITLE
Add prebuild login widget to the navbar

### DIFF
--- a/landing-page/types/headnode/content/styles/login.css
+++ b/landing-page/types/headnode/content/styles/login.css
@@ -1,0 +1,1 @@
+/code/flight-webapp-components/builder/build/static/css/main.css

--- a/landing-page/types/headnode/content/styles/login.css
+++ b/landing-page/types/headnode/content/styles/login.css
@@ -1,1 +1,0 @@
-/code/flight-webapp-components/builder/build/static/css/main.css

--- a/landing-page/types/headnode/layouts/default.html.erb
+++ b/landing-page/types/headnode/layouts/default.html.erb
@@ -27,6 +27,7 @@
     <!-- Our party styles -->
     <link rel="stylesheet" href="<%= prefix_url("/styles/app.css") %>">
     <link rel="stylesheet" href="<%= prefix_url("/styles/branding.css") %>">
+    <link rel="stylesheet" href="<%= prefix_url("/styles/login.css") %>">
 
     <script
         src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
@@ -42,6 +43,12 @@
         src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js"
         integrity="sha384-xrRywqdh3PHs8keKZN+8zzc5TX0GRTLCcmivcbNJWm2rs5C8PRhcEn3czEjhAO9o"
         crossorigin="anonymous">
+    </script>
+    <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
+    <script
+	type="text/javascript"
+	src="<%= prefix_url("/js/login.js") %>">
     </script>
   <script>
     if(window.location.protocol == "http:") {
@@ -116,6 +123,21 @@
           </span>
         </div>
       </footer>
+      <script>
+        const FAM = FlightAccountMenu;
+        const e = React.createElement;
+        const menu = e(
+          FAM.AccountMenu,
+          {},
+          null
+        );
+        const context = e(
+          FAM.CurrentUserProvider,
+          {},
+          menu
+        );
+        ReactDOM.render(context, document.getElementById('flight-account-menu'));
+      </script>
     </div>
   </body>
 </html>

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -88,12 +88,6 @@
             <li class="nav-item">
               <div id="flight-account-menu"></div>
             </li>
-            <li class="nav-item">
-              <div id="flight-account-menu-sm"></div>
-            </li>
-            <li class="nav-item">
-              <div id="flight-account-menu-modal-container"></div>
-            </li>
-	</ul>
+        </ul>
     </div>
 </nav>

--- a/landing-page/types/headnode/layouts/navbar.html.erb
+++ b/landing-page/types/headnode/layouts/navbar.html.erb
@@ -84,5 +84,16 @@
               </li>
             <% end %>
         </ul>
+        <ul class="navbar-nav">
+            <li class="nav-item">
+              <div id="flight-account-menu"></div>
+            </li>
+            <li class="nav-item">
+              <div id="flight-account-menu-sm"></div>
+            </li>
+            <li class="nav-item">
+              <div id="flight-account-menu-modal-container"></div>
+            </li>
+	</ul>
     </div>
 </nav>


### PR DESCRIPTION
This PR is part of a group of PRs which aim to create a static version of the account menu from `flight-webapp-components` and include this static version on `flight-landing-page`.

This PR amends the `headnode` type of `flight-landing-page` to import JS and CSS files (to be created by `flight-webapp-components`, and display the login menu on the landing page navbar.