### PR TITLE
Force Apps to be Pre-Processed Last

### DIFF
--- a/landing-page/Rules
+++ b/landing-page/Rules
@@ -14,6 +14,11 @@ preprocess do
     items.create('', link.merge(kind: 'link'), "/links/#{idx}")
   end
 
+  # Ensure apps is the last of the items to be pre-processed
+  apps_item = @items.find {|i| i.identifier == '/apps.html.erb'}
+  @items.delete_if { |i| i == apps_item }
+  @items.create(apps_item.raw_content, apps_item.attributes, apps_item.identifier)
+
   # layouts.each do |l|
   #   ::STDERR.puts "=== l: #{(l).inspect rescue $!.message}"
   #   ::STDERR.puts "  = l.attributes: #{(l.attributes).inspect rescue $!.message}"


### PR DESCRIPTION
It seems that nanoc does not order files based off of name alone and the order of files can change based on access time (or similar attribute changes).

In the current state of this branch on a fresh installation (from RPM) the apps.html.erb file attempts to process before the rest (which seems correct due to alphabetical things) however this will cause a "binary?" error for "nil:NilClass" (likely related to some of the nesting/looping caused by the "compiled_content" calls).

I'm not sure that I'm explaining this issue correctly but this solution works so let's try not to question it together.

Credit to @mjtko 